### PR TITLE
Issue #3157340: Add CKEditor Templates plugin to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,18 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         },
+        "ckeditor-plugin/templates": {
+            "type": "package",
+            "package": {
+                "name": "ckeditor-plugin/templates",
+                "version": "4.14.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/templates/releases/templates_4.14.0.zip",
+                    "type": "zip"
+                }
+            }
+        },
         "ckeditor-plugin/link": {
             "type": "package",
             "package": {


### PR DESCRIPTION
Diff looks odd because it also sorts plugins alphabetically and because a tab gets replaced with spaces.

Change is the addition of ckeditor templates.

Part of https://www.drupal.org/project/sector/issues/3157340

See also sparksi/sector-distribution#10