### PR TITLE
Use default bin location

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "sparksinteractive/sector-distribution": "^9.1"
     },
     "config": {
-        "bin-dir": "bin/",
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
Do not deviate from established community practice of using default `./vendor/bin` location.