### PR TITLE
Issue #3223719: Prepare for wysiwyg_template update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,19 @@
                 }
             }
         },
+        "ckeditor/templates": {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/templates",
+                "type": "drupal-library",
+                "version": "4.11.1",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://download.ckeditor.com/templates/releases/templates_4.11.1.zip",
+                    "reference": "master"
+                }
+            }
+        },
         "ckeditor-plugin/link": {
             "type": "package",
             "package": {


### PR DESCRIPTION
This is required in order to be able to update to wysiwyg_template:3.0.0-rc2