### PR TITLE
refactor: format On Save and ignore ddev

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.{json,lock}]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,5 @@ web/sites/simpletest
 
 # Ignore Acquia Dev Desktop configs / DDEV.
 web/sites/*.dd
-/.editorconfig
 /.gitattributes
 .ddev

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ web/sites/*/private
 # Ignore SimpleTest multi-site environment.
 web/sites/simpletest
 
-# Ignore Acquia Dev Desktop configs.
+# Ignore Acquia Dev Desktop configs / DDEV.
 web/sites/*.dd
 /.editorconfig
 /.gitattributes
+.ddev

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   "editor.autoIndent": "full",
   "editor.insertSpaces": true,
   "editor.formatOnPaste": true,
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.renderWhitespace": "boundary",
   "editor.wordWrapColumn": 80,
   "editor.wordWrap": "off",


### PR DESCRIPTION
refactor: format On Save, so that you see code change before StyleLinters fix / format code
Ignore .ddev config files by default.
Add root .editorconfig